### PR TITLE
Adds get_attribute and get_cookies method

### DIFF
--- a/caqui/asynchronous.py
+++ b/caqui/asynchronous.py
@@ -122,6 +122,14 @@ async def get_property(driver_url, session, element, property):
     except Exception as error:
         raise WebDriverError("Failed to get value from element.") from error
 
+async def get_attribute(driver_url, session, element, attribute):
+    """Get the given HTML attribute of an element, for example, 'aria-valuenow'"""
+    try:
+        url = f"{driver_url}/session/{session}/element/{element}/attribute/{attribute}"
+        response = await __get(url)
+        return response.get("value")
+    except Exception as error:
+        raise WebDriverError("Failed to get value from element.") from error
 
 async def get_text(driver_url, session, element):
     """Get the text of an element"""

--- a/caqui/asynchronous.py
+++ b/caqui/asynchronous.py
@@ -140,6 +140,14 @@ async def get_text(driver_url, session, element):
     except Exception as error:
         raise WebDriverError("Failed to get text from element.") from error
 
+async def get_cookies(driver_url, session):
+    """Get the page cookies"""
+    try:
+        url = f"{driver_url}/session/{session}/cookie"
+        response = await __get(url)
+        return response.get("value")
+    except Exception as error:
+        raise WebDriverError("Failed to get page cookies.") from error
 
 async def close_session(driver_url, session):
     """Close an opened session and close the browser"""

--- a/caqui/synchronous.py
+++ b/caqui/synchronous.py
@@ -118,6 +118,14 @@ def get_property(driver_url, session, element, property):
     except Exception as error:
         raise WebDriverError("Failed to get value from element.") from error
 
+def get_attribute(driver_url, session, element, attribute):
+    """Get the given HTML attribute of an element, for example, 'aria-valuenow'"""
+    try:
+        url = f"{driver_url}/session/{session}/element/{element}/property/{attribute}"
+        response = __get(url)
+        return response.get("value")
+    except Exception as error:
+        raise WebDriverError("Failed to get value from element.") from error
 
 def go_to_page(driver_url, session, page_url):
     """Navigate to 'page_url'"""

--- a/caqui/synchronous.py
+++ b/caqui/synchronous.py
@@ -121,7 +121,7 @@ def get_property(driver_url, session, element, property):
 def get_attribute(driver_url, session, element, attribute):
     """Get the given HTML attribute of an element, for example, 'aria-valuenow'"""
     try:
-        url = f"{driver_url}/session/{session}/element/{element}/property/{attribute}"
+        url = f"{driver_url}/session/{session}/element/{element}/attribute/{attribute}"
         response = __get(url)
         return response.get("value")
     except Exception as error:

--- a/caqui/synchronous.py
+++ b/caqui/synchronous.py
@@ -127,6 +127,15 @@ def get_attribute(driver_url, session, element, attribute):
     except Exception as error:
         raise WebDriverError("Failed to get value from element.") from error
 
+def get_cookies(driver_url, session):
+    """Get the page cookies"""
+    try:
+        url = f"{driver_url}/session/{session}/cookie"
+        response = __get(url)
+        return response.get("value")
+    except Exception as error:
+        raise WebDriverError("Failed to get page cookies.") from error
+
 def go_to_page(driver_url, session, page_url):
     """Navigate to 'page_url'"""
     try:

--- a/tests/fake_responses.py
+++ b/tests/fake_responses.py
@@ -67,6 +67,15 @@ GET_TITLE = dict_to_json(
     }
 )
 
+GET_COOKIES = dict_to_json(
+    {
+        "sessionId": "07b00b2e94be84920495d83890c82b60",
+        "status": 0,
+        "value": [],
+    }
+)
+
+
 FIND_ELEMENTS = dict_to_json(
     {
         "sessionId": "9be93a374d185216134bf0c3fafee52e",
@@ -80,6 +89,14 @@ FIND_ELEMENTS = dict_to_json(
 )
 
 GET_PROPERTY_VALUE = dict_to_json(
+    {
+        "sessionId": "5be82d4cd17af92d7ea53a36900d78cb",
+        "status": 0,
+        "value": "any_value",
+    }
+)
+
+GET_ATTRIBUTE_VALUE = dict_to_json(
     {
         "sessionId": "5be82d4cd17af92d7ea53a36900d78cb",
         "status": 0,

--- a/tests/unit/test_async_unit.py
+++ b/tests/unit/test_async_unit.py
@@ -27,6 +27,15 @@ async def test_get_property():
     with patch("caqui.asynchronous.__get", mock_post):
         assert await asynchronous.get_property("", "", "", "") == expected
 
+@mark.asyncio
+async def test_get_attribute():
+    expected = "any_value"
+
+    async def mock_post(*args):
+        return fake_responses.GET_ATTRIBUTE_VALUE
+
+    with patch("caqui.asynchronous.__get", mock_post):
+        assert await asynchronous.get_attribute("", "", "", "") == expected
 
 @mark.asyncio
 async def test_get_url():
@@ -72,6 +81,15 @@ async def test_get_title():
     with patch("caqui.asynchronous.__get", mock_post):
         assert await asynchronous.get_title("", "") == expected
 
+@mark.asyncio
+async def test_get_cookies():
+    expected = []
+
+    async def mock_post(*args):
+        return fake_responses.GET_COOKIES
+
+    with patch("caqui.asynchronous.__get", mock_post):
+        assert await asynchronous.get_cookies("", "") == expected
 
 @mark.asyncio
 async def test_get_text():

--- a/tests/unit/test_sync_unit.py
+++ b/tests/unit/test_sync_unit.py
@@ -28,6 +28,11 @@ def test_get_title(*args):
 
     assert synchronous.get_title("", "") == expected
 
+@patch("requests.request", return_value=fake_responses.GET_COOKIES)
+def test_get_cookies(*args):
+    expected = []
+
+    assert synchronous.get_cookies("", "") == expected
 
 @patch("requests.request", return_value=fake_responses.FIND_ELEMENTS)
 def test_find_elements(*args):
@@ -45,6 +50,11 @@ def test_get_property(*args):
 
     assert synchronous.get_property("", "", "", "") == expected
 
+@patch("requests.request", return_value=fake_responses.GET_ATTRIBUTE_VALUE)
+def test_get_attribute(*args):
+    expected = "any_value"
+
+    assert synchronous.get_attribute("", "", "", "") == expected
 
 @patch("requests.request", return_value=fake_responses.GO_TO_PAGE)
 def test_go_to_page(*args):


### PR DESCRIPTION
This can be used to get attributes such as class, aria-label, aria-valuenow, etc.

I have been using caqui and for now it works perfectly. I needed to get the attribute of an element but I couldnt find a method to do so, so here it is. I have tested it and it works fine.

Thanks for the work here!